### PR TITLE
Fix misleading activation error and ensure tailscaled is running

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -333,7 +333,7 @@ else
     ACTIVATION_CODE=$(echo "$ACTIVATION_CODE" | tr '[:lower:]' '[:upper:]' | tr -d ' ')
 
     echo -e "${BLUE}🔗 Activating with Hub...${NC}"
-    ACTIVATE_RESPONSE=$(curl -sf -X POST "$HUB_URL/api/devices/activate" \
+    ACTIVATE_RESPONSE=$(curl -s -X POST "$HUB_URL/api/devices/activate" \
         -H "Content-Type: application/json" \
         -d "{\"nodeInstanceId\": \"$NODE_INSTANCE_ID\", \"activationCode\": \"$ACTIVATION_CODE\"}" 2>/dev/null || echo "")
 
@@ -363,6 +363,8 @@ else
 
             # Join tailnet
             if [ -n "$TS_AUTHKEY" ] && command -v tailscale &>/dev/null; then
+                # Ensure tailscaled is running
+                systemctl start tailscaled 2>/dev/null
                 TS_HOSTNAME=$(hostname -s)
                 TS_ARGS="--authkey=$TS_AUTHKEY --hostname=$TS_HOSTNAME"
                 if [ -n "$TS_LOGIN_SERVER" ]; then


### PR DESCRIPTION
## Summary
- Drop curl `-f` flag so HTTP error responses show actual Hub message (e.g., "Activation code not found or already used") instead of generic "Could not reach Hub"
- Start `tailscaled` daemon before `tailscale up` in case it was stopped