### PR TITLE
Remove NoNewPrivileges from CanBridge service

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -244,7 +244,6 @@ Environment=ASPNETCORE_URLS=http://0.0.0.0:5000
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_SYS_RAWIO
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_SYS_RAWIO
 
-NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true


### PR DESCRIPTION
## Summary
- Remove `NoNewPrivileges=true` from CanBridge systemd service
- This was silently preventing sudo calls (nmcli, reboot, shutdown) from working, causing WiFi scan to return empty results