### PR TITLE
Update Hub URLs for Azure migration

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,8 +21,8 @@ exec > >(tee -a "$LOG_FILE") 2>&1
 log_ts() { echo "[$(date '+%Y-%m-%d %H:%M:%S')]"; }
 
 # --- Configuration ---
-HUB_PREPROD="https://preprod-hub.netglass.io"
-HUB_PROD="https://prod-hub.netglass.io"
+HUB_PREPROD="https://preprod-n1.nobleliftna.com"
+HUB_PROD="https://n1.nobleliftna.com"
 INSTALL_DIR="/opt/canbridge"
 SERVICE_NAME="canbridge"
 SERVICE_USER="canbridge"


### PR DESCRIPTION
## Summary
- Update device provisioning URLs to Azure-hosted Hub
- preprod: preprod-n1.nobleliftna.com
- prod: n1.nobleliftna.com

Do not merge until Azure Hub is deployed and verified.