### PR TITLE
Remove stale Chromium lock file during reinstall

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -383,6 +383,13 @@ step "Configure kiosk environment"
 if $SKIP_KIOSK; then
     skip_msg "Kiosk environment (--skip-kiosk)"
 else
+    # Clean up stale Chromium lock files (hostname changes between installs cause stale locks)
+    CHROMIUM_LOCK="$REAL_HOME/.config/chromium/SingletonLock"
+    if [ -e "$CHROMIUM_LOCK" ]; then
+        rm -f "$CHROMIUM_LOCK"
+        ok "Removed stale Chromium lock file"
+    fi
+
     # HDMI audio blacklist
     if [ ! -f /etc/modprobe.d/blacklist-hdmi-audio.conf ]; then
         echo "blacklist snd_hda_tegra" > /etc/modprobe.d/blacklist-hdmi-audio.conf


### PR DESCRIPTION
- Clean up Chromium SingletonLock at start of kiosk config step
- Fixes Chromium failing to start after reinstall with hostname change
- Lock file points to old hostname, blocking new instance